### PR TITLE
fix: Load correct user data

### DIFF
--- a/modules/profile/userDataSlice.ts
+++ b/modules/profile/userDataSlice.ts
@@ -17,7 +17,7 @@ export interface CourseHistoryState {
 
 export type AcademicDataState = PlannerDataState & CourseHistoryState;
 
-const samplePlan = createSamplePlan();
+export const samplePlan = createSamplePlan();
 
 const initialState: AcademicDataState = {
   user: users.anonymous,

--- a/pages/app/index.tsx
+++ b/pages/app/index.tsx
@@ -13,7 +13,7 @@ import PlanCard from './PlanCard';
 import { v4 as uuid } from 'uuid';
 import { useRouter } from 'next/router';
 import AddIcon from '@material-ui/icons/Add';
-import { updateUser, updateAllUserData } from '../../modules/profile/userDataSlice';
+import { updateUser, updateAllUserData, samplePlan } from '../../modules/profile/userDataSlice';
 import { useAuthContext } from '../../modules/auth/auth-context';
 import firebase from 'firebase';
 
@@ -49,10 +49,22 @@ export default function Home(): JSX.Element {
       .doc(user.id)
       .get()
       .then((userDoc) => {
-        console.log('doc exists');
-        if (userDoc) {
+        if (userDoc.exists) {
+          console.log('doc exists');
           const userData = userDoc.data();
           const userSlice = userData.userDataSlice;
+          dispatch(updateAllUserData(userSlice));
+        } else {
+          // creates sample data if there is no record in firebase
+          // no need to save it in firebase as it will save later if the user edits their plan
+          const userSlice = {
+            user: user,
+            plans: {
+              [samplePlan.id]: samplePlan,
+            },
+            planIds: [samplePlan.id],
+            courses: [],
+          };
           dispatch(updateAllUserData(userSlice));
         }
       })


### PR DESCRIPTION
## Overview

Resolves #74 

This fix allows users not yet stored in the firebase database to see sample plan data rather than that of a previous account.

## What Changed

When the user was directed to the Home screen after logging in, there was an incorrect check in the code where it was always assumed that a user was in the firebase database. There is a correct check now for the document and an alternative when the user is not stored in the database.

## Other Notes

This bug can also be solved by making sure that the user is placed in the database on signup with a sample plan provided in order for them to avoid seeing the previous user's plan data.
