### PR TITLE
feat(planner): Implement delete degree plan functionality

### DIFF
--- a/components/planner/PlanningToolbar/PlannerSettings.tsx
+++ b/components/planner/PlanningToolbar/PlannerSettings.tsx
@@ -8,7 +8,9 @@ import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
 import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '../../../modules/redux/store';
-import { updatePlan } from '../../../modules/redux/userDataSlice';
+import { deletePlan, updatePlan } from '../../../modules/redux/userDataSlice';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { useRouter } from 'next/router';
 
 export type SettingsDialogProps = {
   planId: string;
@@ -43,6 +45,7 @@ export default function SettingsDialog({
 
   const [title, setTitle] = React.useState('');
   const [major, setMajor] = React.useState('');
+  const router = useRouter();
 
   const handleClose = () => {
     setOpen(false);
@@ -55,6 +58,23 @@ export default function SettingsDialog({
     dispatch(updatePlan(newPlan));
     updatePlanTitle(title);
     setOpen(false);
+  };
+
+  // Open
+
+  const handleAlertOpen = () => {
+    setAlertOpen(true);
+  };
+
+  const handleDeletePlan = () => {
+    dispatch(deletePlan(planId));
+    handleAlertClose();
+    router.push('/app/plans');
+  };
+
+  const [alertOpen, setAlertOpen] = React.useState(false);
+  const handleAlertClose = () => {
+    setAlertOpen(false);
   };
 
   return (
@@ -83,6 +103,32 @@ export default function SettingsDialog({
             fullWidth
             onChange={(event) => setMajor(event.target.value)}
           />
+          <div className="col-span-2 flex justify-center items-center pt-2">
+            <Button className="w-30" onClick={handleAlertOpen}>
+              <DeleteIcon color="action" />
+              Delete Plan
+            </Button>
+          </div>
+
+          <Dialog
+            open={alertOpen}
+            onClose={handleAlertClose}
+            aria-labelledby="alert-dialog-title"
+            aria-describedby="alert-dialog-description"
+          >
+            <DialogTitle id="alert-dialog-title">{'Delete Plan'}</DialogTitle>
+            <DialogContent>
+              <DialogContentText id="alert-dialog-description">
+                Are you sure you want to delete this plan?
+              </DialogContentText>
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={handleAlertClose}>No</Button>
+              <Button onClick={handleDeletePlan} autoFocus>
+                Yes
+              </Button>
+            </DialogActions>
+          </Dialog>
         </DialogContent>
         <DialogActions>
           <Button onClick={handleClose} color="primary">

--- a/modules/redux/userDataSlice.ts
+++ b/modules/redux/userDataSlice.ts
@@ -110,6 +110,7 @@ export const loadUser = createAsyncThunk<
 
 /**
  * Stores user data to firebase
+ * TODO: Have saveToFirebase automatically run each time a reducer is called
  * @param id user ID
  * @param data user's academic data
  */
@@ -135,7 +136,6 @@ const userDataSlice = createSlice({
       const resultingState = { ...state, courses: action.payload };
       const userDataSlice = { userDataSlice: resultingState };
       saveToFirebase(unique_id, userDataSlice);
-
       return resultingState;
     },
     updatePlan(state, action: PayloadAction<StudentPlan>) {
@@ -143,6 +143,12 @@ const userDataSlice = createSlice({
       state.plans[action.payload.id] = action.payload;
       const userDataSlice = { userDataSlice: JSON.parse(JSON.stringify(state)) };
       saveToFirebase(unique_id, userDataSlice);
+      return state;
+    },
+    deletePlan(state, action: PayloadAction<string>) {
+      delete state.plans[action.payload];
+      const userDataSlice = { userDataSlice: JSON.parse(JSON.stringify(state)) };
+      saveToFirebase(state.user.id, userDataSlice);
       return state;
     },
     updateAllUserData(state, action: PayloadAction<AcademicDataState>) {
@@ -182,6 +188,7 @@ export const {
   updateUser,
   updateCourseAudit,
   updatePlan,
+  deletePlan,
   updateAllUserData,
   resetStore,
   updateOnboarding,


### PR DESCRIPTION
Users can now delete a degree plan through the settings dialog inside the degree
planning tool.

Resolves #71 

