### PR TITLE
chore: Change GitHub issue assignee

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_issue_template.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_issue_template.yml
@@ -3,7 +3,7 @@ description: File a bug report
 title: '[Bug]: '
 labels: ['Type: Bug Report', 'Status: Awaiting Triage']
 assignees:
-  - WillieCubed
+  - rajmeet2001
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request_issue_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_request_issue_template.md
@@ -3,7 +3,7 @@ name: Feature Request
 about: Think of something you would like added to this project? This is how to do it.
 title: '[Feature Request]'
 labels: 'Type: Feature Request, Category: User Experience, Status: Awaiting Triage'
-assignees: 'WillieCubed'
+assignees: 'rajmeet2001'
 ---
 
 # Overview


### PR DESCRIPTION
Rajmeet will be the new default assignee for Github issues instead of Willie.