### PR TITLE
feat(auth): Support anonymous user sign-in

### DIFF
--- a/components/auth/AuthCard.tsx
+++ b/components/auth/AuthCard.tsx
@@ -64,11 +64,11 @@ export default function AuthCard({ authState }: AuthCardProps): JSX.Element {
 
   /**
    * Runs whenever an invalid route is passed
-   * into /app/auth
+   * into /auth
    */
   function invalidAction() {
     console.error('Invalid route, returning to login screen.');
-    router.push('/app/auth/login');
+    router.push('/auth/login');
   }
 
   /**

--- a/components/auth/Login.tsx
+++ b/components/auth/Login.tsx
@@ -58,7 +58,7 @@ export default function AuthCard(): JSX.Element {
           ></input>
         </div>
         <div className="">
-          <Link href="/app/auth/reset">
+          <Link href="/auth/reset">
             <a className="font-semibold text-blue-700 hover:bg-blue-100 rounded-lg">
               Forgot password?
             </a>
@@ -82,7 +82,7 @@ export default function AuthCard(): JSX.Element {
         <div className="flex place-content-center">
           <p>
             New to Nebula?
-            <Link href="/app/auth/signup">
+            <Link href="/auth/signup">
               <a className="ml-2 text-blue-700 font-semibold hover:bg-blue-200 hover:rounded-lg">
                 Sign Up
               </a>

--- a/components/auth/Signup.tsx
+++ b/components/auth/Signup.tsx
@@ -113,7 +113,7 @@ export default function AuthCard(): JSX.Element {
         <div className="flex place-content-center">
           <p>
             Already have an account?
-            <Link href="/app/auth/login">
+            <Link href="/auth/login">
               <a className="ml-2 text-blue-700 font-semibold hover:bg-blue-200 hover:rounded-lg">
                 Sign In
               </a>

--- a/components/common/AppNavigation/AppNavigation.tsx
+++ b/components/common/AppNavigation/AppNavigation.tsx
@@ -14,13 +14,13 @@ import { useAuthContext } from '../../../modules/auth/auth-context';
  */
 export default function AppNavigation(): JSX.Element {
   // TODO: Highlight active item based on current location
-  const { isSignedIn } = useAuthContext();
+  const { isUserSignedIn } = useAuthContext();
 
   /* Decides if the button should be login or 
   sign out based on the current auth state */
   const authItem = {
-    route: isSignedIn ? '/app/auth/signOut' : '/app/auth/login',
-    label: isSignedIn ? 'Sign out' : 'Sign in',
+    route: isUserSignedIn ? '/app/auth/signOut' : '/app/auth/login',
+    label: isUserSignedIn ? 'Sign out' : 'Sign in',
   };
 
   return (

--- a/components/common/AppNavigation/AppNavigation.tsx
+++ b/components/common/AppNavigation/AppNavigation.tsx
@@ -19,7 +19,7 @@ export default function AppNavigation(): JSX.Element {
   /* Decides if the button should be login or 
   sign out based on the current auth state */
   const authItem = {
-    route: isUserSignedIn ? '/app/auth/signOut' : '/app/auth/login',
+    route: isUserSignedIn ? '/auth/signOut' : '/auth/login',
     label: isUserSignedIn ? 'Sign out' : 'Sign in',
   };
 

--- a/components/common/toolbar/ProfileIcon/ProfileIcon.tsx
+++ b/components/common/toolbar/ProfileIcon/ProfileIcon.tsx
@@ -43,7 +43,7 @@ export default function ProfileIcon(props: ProfileIconProps): JSX.Element {
 
   const { name, image } = user;
 
-  const isSignedIn = user.id !== 'guest';
+  const { isUserSignedIn } = useAuthContext();
 
   const userData = {
     classification: 'Junior',
@@ -51,7 +51,7 @@ export default function ProfileIcon(props: ProfileIconProps): JSX.Element {
   };
 
   const avatarIcon =
-    isSignedIn && image != null ? (
+    isUserSignedIn && image != null ? (
       <Avatar alt={image} src={image} />
     ) : (
       <Avatar alt={name}>
@@ -97,7 +97,7 @@ export default function ProfileIcon(props: ProfileIconProps): JSX.Element {
             </div>
           </div>
         </div>
-        {isSignedIn ? (
+        {isUserSignedIn ? (
           [
             <MenuItem component={Link} href="/app/profile" key="profile">
               <ListItemIcon>

--- a/components/common/toolbar/ProfileIcon/ProfileIcon.tsx
+++ b/components/common/toolbar/ProfileIcon/ProfileIcon.tsx
@@ -105,7 +105,7 @@ export default function ProfileIcon(props: ProfileIconProps): JSX.Element {
               </ListItemIcon>
               <ListItemText primary="Manage profile" />
             </MenuItem>,
-            <MenuItem component={Link} href="/app/auth/signOut" key="auth">
+            <MenuItem component={Link} href="/auth/signOut" key="auth">
               <ListItemIcon>
                 <ExitToApp />
               </ListItemIcon>
@@ -113,7 +113,7 @@ export default function ProfileIcon(props: ProfileIconProps): JSX.Element {
             </MenuItem>,
           ]
         ) : (
-          <MenuItem component={Link} href="/app/auth/Login">
+          <MenuItem component={Link} href="/auth/Login">
             <ListItemIcon>
               <ExitToApp />
             </ListItemIcon>

--- a/components/home/NavigationBar.tsx
+++ b/components/home/NavigationBar.tsx
@@ -10,7 +10,7 @@ export default function HomeNavigationBar() {
   const router = useRouter();
 
   const authItem = {
-    route: isUserSignedIn ? '/app/auth/signOut' : '/app/auth/Login',
+    route: isUserSignedIn ? '/auth/signOut' : '/auth/Login',
     label: isUserSignedIn ? 'Sign out' : 'Sign in',
   };
 

--- a/components/home/NavigationBar.tsx
+++ b/components/home/NavigationBar.tsx
@@ -6,12 +6,12 @@ import { useRouter } from 'next/router';
 
 // TODO: Unused; refactor navigationbar for Planner v1
 export default function HomeNavigationBar() {
-  const { isSignedIn } = useAuthContext();
+  const { isUserSignedIn } = useAuthContext();
   const router = useRouter();
 
   const authItem = {
-    route: isSignedIn ? '/app/auth/signOut' : '/app/auth/Login',
-    label: isSignedIn ? 'Sign out' : 'Sign in',
+    route: isUserSignedIn ? '/app/auth/signOut' : '/app/auth/Login',
+    label: isUserSignedIn ? 'Sign out' : 'Sign in',
   };
 
   const handleAuthUpdate = () => {

--- a/modules/redux/userDataSlice.ts
+++ b/modules/redux/userDataSlice.ts
@@ -44,7 +44,7 @@ const sampleOnboarding = createSampleOnboarding();
 const initialState: AcademicDataState = {
   onboarding: sampleOnboarding,
   doneOnboarding: false,
-  user: users.anonymous,
+  user: users.unauthenticated,
   plans: {
     [samplePlan.id]: samplePlan,
   },
@@ -75,13 +75,13 @@ export const loadUser = createAsyncThunk<
   { state: { userData: AcademicDataState } }
 >('userData/loadUser', async (user: ServiceUser, { getState }) => {
   const firestore = firebase.firestore();
+  let userSlice: AcademicDataState = JSON.parse(JSON.stringify(getState().userData));
   if (user.id !== 'guest') {
     const slice = await firestore
       .collection('users')
       .doc(user.id)
       .get()
       .then((userDoc) => {
-        let userSlice: AcademicDataState;
         if (userDoc.data() !== undefined) {
           // Return user data
           const userData = userDoc.data();
@@ -90,7 +90,6 @@ export const loadUser = createAsyncThunk<
           // Create new user data
           // If the user was previously a guest, load all
           // guest created plans to new data
-          userSlice = JSON.parse(JSON.stringify(getState().userData));
           userSlice.user = JSON.parse(JSON.stringify(user));
           // userSlice.plans = plans;
 
@@ -105,6 +104,11 @@ export const loadUser = createAsyncThunk<
         console.log('error: ', error);
       });
     return slice as AcademicDataState;
+  } else {
+    // Update authentication state for guest user
+    userSlice.user = user;
+    delete userSlice.user.requiresAuthentication;
+    return userSlice;
   }
 });
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -41,7 +41,7 @@ if (!firebase.apps.length) {
  * @returns boolean
  */
 const needAppNav = (pathname: string): boolean => {
-  const routesList = ['/app/onboarding', '/app/auth', '/app/plans/'];
+  const routesList = ['/app/onboarding', '/auth', '/app/plans/'];
   if (pathname === '/') {
     return true;
   }

--- a/pages/app/routes/[route].tsx
+++ b/pages/app/routes/[route].tsx
@@ -16,10 +16,11 @@ export default function Routing() {
   const data = useSelector((state: RootState) => state.userData);
 
   // Runs whenever user is updated
+  // TODO: Handle edge case if user signs into actual account after using guest account
+  // i.e. find a way to smoothly save the data
   React.useEffect(() => {
     if (user) {
       console.info('User has changed.', user);
-
       // Sync Redux & Firebase
       dispatch(loadUser(user));
       setSync(true);

--- a/pages/auth/[task].tsx
+++ b/pages/auth/[task].tsx
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router';
 import React from 'react';
-import AuthCard from '../../../components/auth/AuthCard';
+import AuthCard from '../../components/auth/AuthCard';
 
 /**
  * A page that presents a sign-in/sign-up box to the user.

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,6 +3,7 @@ import Footer from '../components/common/Footer';
 import React from 'react';
 import Link from 'next/link';
 import ServiceName from '../components/common/ServiceName';
+import { useAuthContext } from '../modules/auth/auth-context';
 
 /**
  * The primary landing page for the application.
@@ -13,6 +14,11 @@ import ServiceName from '../components/common/ServiceName';
  * TODO: also show some lightweight interactive demos since why not.
  */
 export default function LandingPage(): JSX.Element {
+  const { signInAsGuest } = useAuthContext();
+  const handleSignInAsGuest = () => {
+    signInAsGuest();
+  };
+
   return (
     <div className="min-w-screen min-h-screen bg-gray-800">
       <Head>
@@ -32,6 +38,7 @@ export default function LandingPage(): JSX.Element {
             <button className="p-2 rounded-md shadow-md hover:shadow-lg bg-secondary font-bold text-button uppercase">
               <Link href="/app/auth/login">Get Started 🌌</Link>
             </button>
+            <button onClick={handleSignInAsGuest}>Continue as Guest</button>
           </div>
         </div>
       </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -36,7 +36,7 @@ export default function LandingPage(): JSX.Element {
           <div className="text-headline6">Tools to help you plan out your college career.</div>
           <div className="my-4">
             <button className="p-2 rounded-md shadow-md hover:shadow-lg bg-secondary font-bold text-button uppercase">
-              <Link href="/app/auth/login">Get Started 🌌</Link>
+              <Link href="/auth/login">Get Started 🌌</Link>
             </button>
             <button onClick={handleSignInAsGuest}>Continue as Guest</button>
           </div>


### PR DESCRIPTION
## Overview

There is now a clear distinction between unauthenticated users and authenticated
users.

Resolves #76 

## What Changed

 When a user signs into Planner anonymously, they are given the "guest" id
and are able to use the application just like a regular user. However, if a user
is unauthenticated, then all routes that begin with "/app" will redirect to the
Landing page

