### PR TITLE
feat(planner): Add protected routes for plans page

### DIFF
--- a/modules/planner/hooks/usePlan.ts
+++ b/modules/planner/hooks/usePlan.ts
@@ -1,8 +1,9 @@
 import React from 'react';
 import { Semester, StudentPlan } from '../../common/data';
-import DUMMY_PLAN from '../../../data/add_courses.json';
 import { useDispatch, useStore } from 'react-redux';
 import { updatePlan } from '../../redux/userDataSlice';
+import { initialPlan } from '../plannerUtils';
+import { useRouter } from 'next/router';
 
 /**
  * A utility hook that exposes callbacks to handle manipulating the StudentPlan.
@@ -17,13 +18,7 @@ export function usePlan() {
 
   const dispatch = useDispatch();
 
-  // Initial value for plan until data is properly loaded
-  const initialPlan: StudentPlan = {
-    id: planId,
-    title: 'Just a Degree Plan',
-    major: 'Computer Science',
-    semesters: DUMMY_PLAN,
-  };
+  const router = useRouter();
 
   // Manages plan state
   const [plan, setPlan] = React.useState<StudentPlan>(initialPlan);
@@ -106,12 +101,10 @@ export function usePlan() {
   };
 
   /**
-   * TODO: Get the StudentPlan from Firebase if exists
-   * TODO: After completing newPlanFow, automatically populate state.userData.plans[planId]
-   * with correct plan and remove initialPlan
-   *
    * The fetchPlan function returns a StudentPlan from an external storage
    * given a planId.
+   *
+   * If no such plan exists, redirect the user back to the plans page
    *
    * @param planId unique identifier for each plan
    * @returns a StudentPlan
@@ -120,10 +113,10 @@ export function usePlan() {
     // Make copy of student plan from redux or get default plan if doesn't exist
     const plan: StudentPlan = store.getState().userData.plans[planId] ?? initialPlan;
     if (plan.id !== 'empty-plan') {
-      // Remove this logic once initialPlan deprecated
       return JSON.parse(JSON.stringify(plan));
     } else {
-      plan.id = planId;
+      // Redirect back to '/app/plans'
+      router.push('/app/plans');
       return plan;
     }
   }

--- a/modules/planner/plannerUtils.ts
+++ b/modules/planner/plannerUtils.ts
@@ -1,5 +1,14 @@
 import { RecentSemester } from '../../components/planner/PlannerContainer';
-import { Semester, SemesterCode } from '../common/data';
+import { Semester, SemesterCode, StudentPlan } from '../common/data';
+import DUMMY_PLAN from '../../data/add_courses.json';
+
+// Initial value for plan until data is properly loaded
+export const initialPlan: StudentPlan = {
+  id: 'empty-plan',
+  title: 'Just a Degree Plan',
+  major: 'Computer Science',
+  semesters: DUMMY_PLAN,
+};
 
 /**
  * This function generates the metadata needed

--- a/pages/app/plans/index.tsx
+++ b/pages/app/plans/index.tsx
@@ -2,9 +2,11 @@ import React from 'react';
 import PlanCard from '../../../components/home/plans/PlanCard';
 import AddIcon from '@mui/icons-material/Add';
 import { useRouter } from 'next/router';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '../../../modules/redux/store';
 import { v4 as uuid } from 'uuid';
+import { updatePlan } from '../../../modules/redux/userDataSlice';
+import { initialPlan } from '../../../modules/planner/plannerUtils';
 
 /**
  * A list of the user's plans
@@ -15,6 +17,8 @@ export default function PlansPage(): JSX.Element {
 
   const router = useRouter();
 
+  const dispatch = useDispatch();
+
   // TODO: Write function to get user plans
   const { plans: userPlans } = useSelector((state: RootState) => state.userData);
   const plans = Object.values(userPlans);
@@ -22,6 +26,9 @@ export default function PlansPage(): JSX.Element {
   const handleCreatePlan = async () => {
     // Generate route id
     const routeID = uuid();
+    const newPlan = initialPlan;
+    newPlan.id = routeID;
+    dispatch(updatePlan(newPlan));
     router.push(`/app/plans/${routeID}`);
   };
 


### PR DESCRIPTION
This pull request resolves #110.

1. Routes that start with '/app' should require the user to be authenticated in order to access.
 - If this condition is not satisfied, redirect the user to the landing page.
Note: anonymous users still need to sign in as a "guest user" in order to gain access 

2. The route '/app/plans/[planId]' should require a valid plan to exist.
- If this condition is not satisfied, redirect the user to '/app/plans'
