### PR TITLE
chore(tailwind.config.js): Add Nebula colors to tailwind config

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,12 @@ module.exports = {
   theme: {
     extend: {
       colors: {
+        general: {
+          primary: '#4659A7',
+          secondary: '#BCC9FD',
+          accentOne: '#FBBB78',
+          accentTwo: '#A7EDE9',
+        },
         primary: {
           light: '#6470F7',
           DEFAULT: '#2F3FF4',


### PR DESCRIPTION
The main colors used in Planner have been added to the tailwind config file.
Now, devs can use the tailwind class "general-[color] to add a specific color instead of using the
exact hexadecimal color code
<img width="158" alt="Screen Shot 2022-09-04 at 2 42 42 PM" src="https://user-images.githubusercontent.com/47403443/188330845-a1fe7529-098c-4fc3-83aa-73363ea79a56.png">
