### PR TITLE
Bump TS target from es5 => es6

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
``IteratorIterable`` is [only available in ES6](https://exploringjs.com/es6/ch_iteration.html#sec_implementing-iterables), which introduces ``Array.prototype.entries``. Just a nice-to-have.

It would be very surprising if any of our target users are using a 2015 browser, IE, or Opera Mini. See: https://caniuse.com/?search=es6