### PR TITLE
fix: Update landing page meta tags

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,8 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
-  <title>Planner</title>
-  <meta property="og:title" content="Planner">
+  <title>Nebula Planner</title>
+  <meta name="description" content="Say goodbye to the stress and hassle of degree planning and hello to a smooth, organized path towards graduation with Nebula Planner.">
+  <meta property="og:title" content="Nebula Planner">
   <meta property="og:description" content="Say goodbye to the stress and hassle of degree planning and hello to a smooth, organized path towards graduation with Nebula Planner.">
   <meta property="og:image" content="/img.png">
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />


### PR DESCRIPTION
## Overview (and What Changed)

No associated issues here. I just saw a thing and thought I would propose a spot fix.

This updates the title of the landing page to "Nebula Planner" instead of just "Planner", which should help provide more context to the product. This commit also adds a missing description meta tag and uses the existing og:description as its content just in case a site does not use OpenGraph meta tags.
