### PR TITLE
docs: fixed validator url

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ npm install
 
     ```bash
     # DEGREE VALIDATOR
-    VALIDATOR=http://localhost:5000
+    NEXT_PUBLIC_VALIDATOR=http://127.0.0.1:5000
     ```
 
 9.  Generate `Prisma` client and run web server:


### PR DESCRIPTION
I updated the documentation for setting up planner with the correct environment variable.